### PR TITLE
Handle client side timeouts

### DIFF
--- a/internal/sthttp/sthttp.go
+++ b/internal/sthttp/sthttp.go
@@ -8,6 +8,7 @@ import (
 	"log"
 	"net"
 	"net/http"
+  "net/url"
 	"sort"
 	"strings"
 	"time"
@@ -366,7 +367,14 @@ func (stClient *Client) GetFastestServer(servers []Server) Server {
 		}
 		latency, err := stClient.GetLatency(servers[server], stClient.GetLatencyURL(servers[server]))
 		if err != nil {
-			log.Fatal(err)
+      urlerr, ok := err.(*url.Error)
+      // If error is a url error and has timed out
+      if ok && urlerr.Timeout() {
+				log.Printf("Server %d timed out, skipping...\n", server)
+        continue
+      } else {
+        log.Fatal(err)
+      }
 		}
 
 		if stClient.Debug {

--- a/internal/sthttp/sthttp.go
+++ b/internal/sthttp/sthttp.go
@@ -370,7 +370,9 @@ func (stClient *Client) GetFastestServer(servers []Server) Server {
       urlerr, ok := err.(*url.Error)
       // If error is a url error and has timed out
       if ok && urlerr.Timeout() {
-				log.Printf("Server %d timed out, skipping...\n", server)
+        if stClient.Debug {
+          log.Printf("Server %d timed out, skipping...\n", server)
+        }
         continue
       } else {
         log.Fatal(err)
@@ -389,14 +391,19 @@ func (stClient *Client) GetFastestServer(servers []Server) Server {
 			if stClient.Debug {
 				log.Printf("Server latency was ok %f adding to successful servers list", latency)
 			}
-			successfulServers = append(successfulServers, servers[server])
-			successfulServers[server].Latency = latency
+      newServer := servers[server]
+      newServer.Latency = latency
+			successfulServers = append(successfulServers, newServer)
 		}
 
 		if len(successfulServers) == stClient.SpeedtestConfig.NumClosest {
 			break
 		}
 	}
+
+  if len(successfulServers) <= 0 {
+    log.Fatal("No servers responded")
+  }
 
 	sort.Sort(ByLatency(successfulServers))
 	if stClient.Debug {

--- a/internal/sthttp/sthttp_test.go
+++ b/internal/sthttp/sthttp_test.go
@@ -10,6 +10,8 @@ import (
 	"sort"
 	"testing"
 	"time"
+  "log"
+  "bytes"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -311,15 +313,21 @@ func TestFastestServerWithTimeout(t *testing.T) {
 	stc := Client{
     SpeedtestConfig: &SpeedtestConfig{ServersURL: listServer.URL, NumLatencyTests: 1},
 		HTTPConfig:      &HTTPConfig{HTTPTimeout: timeout},
+    Debug:           true,
 	}
 	servers, err := stc.GetServers()
 	if err != nil {
 		t.Logf("Cannot get servers")
 		t.Fatal(err)
 	}
-
-  // Make sure correct server returned
+  
+  var buf bytes.Buffer
+  log.SetOutput(&buf)
 	fs := stc.GetFastestServer(servers)
+  log.SetOutput(os.Stdout)
+  // Make sure timeout was logged
+  assert.True(t, bytes.Contains(buf.Bytes(), []byte("Server 0 timed out")), "Timeout must be logged")
+  // Make sure correct server returned
 	assert.NotNil(t, fs, "No fastest server returned")
   assert.Equal(t, fs.Name, "fast", "Fast server should be returned")
 }


### PR DESCRIPTION
This fixes #112 and includes:

- Changes to GetFastestServer to skip on timeout
- Additional test case for this behavior
- Check for zero length successful servers